### PR TITLE
Fix Makefile virtualenv warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ifndef CI
 ifndef VIRTUAL_ENV
-	$(error Please use virtualenv)
+$(error Please use virtualenv)
 endif
 endif
 


### PR DESCRIPTION
This PR fixes the Makefile so that it warns you when your virtualenv isn't activated (instead of given you this `Makefile:3: *** commands commence before first target.  Stop.` opaque error)